### PR TITLE
fix: truncate state history ut

### DIFF
--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -636,16 +636,23 @@ func TestTailTruncateHistory(t *testing.T) {
 	tester := newTester(t, 10)
 	defer tester.release()
 
-	tester.db.Close()
-	tester.db = New(tester.db.diskdb, &Config{StateHistory: 10}, false)
+	// ignore error, whether `Journal` success or not, this UT must succeed
+	_ = tester.db.Journal(tester.lastHash())
+	_ = tester.db.Close()
 
+	tester.db = New(tester.db.diskdb, &Config{StateHistory: 10}, false)
 	head, err := tester.db.freezer.Ancients()
 	if err != nil {
 		t.Fatalf("Failed to obtain freezer head")
 	}
-	stored := rawdb.ReadPersistentStateID(tester.db.diskdb)
-	if head != stored {
-		t.Fatalf("Failed to truncate excess history object above, stored: %d, head: %d", stored, head)
+	bottom := tester.db.tree.bottom().id
+	if head != bottom {
+		t.Fatalf("Failed to truncate excess history object above, bottom: %d, head: %d", bottom, head)
+	}
+	persistID := rawdb.ReadPersistentStateID(tester.db.diskdb)
+	diffLayers := tester.db.tree.bottom().buffer.getLayers()
+	if persistID != bottom && head != persistID+diffLayers {
+		t.Fatalf("Failed to truncate excess history object above, bottom: %d, persistID: %d, diffLayers: %d", bottom, persistID, diffLayers)
 	}
 }
 


### PR DESCRIPTION
### Description

Fix truncates state history UT error.

### Rationale

NO.

### Example

NO.

### Changes

Notable changes: 
NO.
